### PR TITLE
fix: fix errors caused by changes in immich API and fix build fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM alpine:3.18.4
 # Installing required packages
 FROM alpine/doctl
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
+RUN apk add --update --no-cache python3 py-pip && ln -sf python3 /usr/bin/python
+#RUN python3 -m ensurepip
+RUN pip3 install --break-system-packages --no-cache --upgrade pip setuptools
 
 # Install package
 WORKDIR /code
 COPY . .
-RUN pip3 install .
+RUN pip3 install --break-system-packages .
 
 ENV IMMICH_API_TOKEN=""
 ENV IMMICH_HOST=""

--- a/immich_exporter/exporter.py
+++ b/immich_exporter/exporter.py
@@ -43,7 +43,7 @@ class ImmichMetricsCollector:
 
         metrics = []
         metrics.extend(self.get_immich_server_version_number())
-        metrics.extend(self.get_immich_server_info())
+        metrics.extend(self.get_immich_storage())
         metrics.extend(self.get_immich_users_stat)
         metrics.extend(self.get_immich_users_stat_growth())
 
@@ -131,16 +131,13 @@ class ImmichMetricsCollector:
 
         for x in range(0, user_count):
             metrics.append(
-
                 {
                     "name": f"{self.config['metrics_prefix']}_server_stats_photos_by_users",
                     "value": user_data[x]['photos'],
                     "labels": {
                         "firstName": user_data[x]["userName"].split()[0],
-
                     },
                     "help": f"Number of photos by user {user_data[x]['userName'].split()[0]} "
-
                 }
             )
 
@@ -152,10 +149,8 @@ class ImmichMetricsCollector:
                     "value": user_data[x]['videos'],
                     "labels": {
                         "firstName": user_data[x]["userName"].split()[0],
-
                     },
                     "help": f"Number of photos by user {user_data[x]['userName'].split()[0]} "
-
                 }
             )
         # usage
@@ -166,49 +161,48 @@ class ImmichMetricsCollector:
                     "value": (user_data[x]['usage']),
                     "labels": {
                         "firstName": user_data[x]["userName"].split()[0],
-
                     },
                     "help": f"Number of photos by user {user_data[x]['userName'].split()[0]} "
-
                 }
             )
 
         return metrics
 
-    def get_immich_server_info(self):
-
+    def get_immich_storage(self):
         try:
-            endpoint_server_info = "/api/server-info"
-            response_server_info = requests.request(
+            endpoint_storage = "/api/server-info/storage"
+            response_storage = requests.request(
                 "GET",
-                self.combine_url(endpoint_server_info),
+                self.combine_url(endpoint_storage),
                 headers={'Accept': 'application/json',
                          "x-api-key": self.config["token"]}
             )
         except requests.exceptions.RequestException as e:
-            logger.error(f"Couldn't get server version: {e}")
+            logger.error(f"Couldn't get storage info: {e}")
+            
+        response_json = response_storage.json()
 
         return [
             {
                 "name": f"{self.config['metrics_prefix']}_server_info_diskAvailable",
-                "value": (response_server_info.json()["diskAvailableRaw"]),
+                "value": (response_json["diskAvailableRaw"]),
                 "help": "Available space on disk",
             },
             {
                 "name": f"{self.config['metrics_prefix']}_server_info_totalDiskSize",
-                "value": (response_server_info.json()["diskSizeRaw"]),
+                "value": (response_json["diskSizeRaw"]),
                 "help": "total disk size",
                 # "type": "counter"
             },
             {
                 "name": f"{self.config['metrics_prefix']}_server_info_diskUse",
-                "value": (response_server_info.json()["diskUseRaw"]),
+                "value": (response_json["diskUseRaw"]),
                 "help": "disk space in use",
                 # "type": "counter"
             },
             {
                 "name": f"{self.config['metrics_prefix']}_server_info_diskUsagePercentage",
-                "value": (response_server_info.json()["diskUsagePercentage"]),
+                "value": (response_json["diskUsagePercentage"]),
                 "help": "disk usage in percent",
                 # "type": "counter"
             }


### PR DESCRIPTION
fixes issue #10 

We need to call of `/api/server-info/storage` instead of just `/api/server-info`

Also fixed build fails because of the following error:
```
× This environment is externally managed
╰─> 
    The system-wide python installation should be maintained using the system
    package manager (apk) only.
...
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```