### PR TITLE
Reworked docker build, smaller docker image, arm support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 __pycache__/
 .coverage*
+.git
+.idea
 .github
 .gitignore
 .pdm*


### PR DESCRIPTION
Fixes #22 and #21

Finally image size: amd -> 150 MB, arm -> 180 MB
I have tested only amd image with my immich server and it works fine.
Not sure if `--break-system-packages` is needed, but not needed for me.

To build for booth platform you need to (previous way of build for amd64 work as before):
- add arm instructions: `docker run --privileged --rm tonistiigi/binfmt --install arm64`
- add docker container with docker driver: `docker buildx create --name container --driver docker-container --platform linux/amd64,linux/386,linux/arm64`
- `docker buildx use container --default --global`
- build: `docker buildx build . -t <REGISTRY> --platform linux/amd64,linux/arm64 --push`